### PR TITLE
Fixes #234: Correct vite config file extensions on non kit and typescript projects

### DIFF
--- a/__info.js
+++ b/__info.js
@@ -1,3 +1,6 @@
+import { forEachLeadingCommentRange } from "typescript";
+import { getViteConfigFilePath } from "../../adder-tools";
+
 export const name = "Imagetools";
 
 export const emoji = "🖼";
@@ -24,7 +27,7 @@ export const heuristics = [
 	},
 	{
 		description: "The vite-imagetools plugin is set up",
-		async detector({ readFile }) {
+		async detector({ readFile, folderInfo }) {
 			/** @param {string} text */
 			const vitePluginIsProbablySetup = (text) => {
 				if (!text.includes("vite-imagetools")) return false;
@@ -33,7 +36,7 @@ export const heuristics = [
 				return true;
 			};
 
-			const vite = await readFile({ path: "/vite.config.js" });
+			const vite = await readFile({ path: `/${getViteConfigFilePath(folderInfo)}` });
 
 			if (vitePluginIsProbablySetup(vite.text)) return true;
 

--- a/__run.js
+++ b/__run.js
@@ -2,7 +2,7 @@ import { updateViteConfig } from "../../adder-tools.js";
 import { addImport, findImport, setDefault } from "../../ast-tools.js";
 
 /** @type {import("../..").AdderRun<import("./__info.js").Options>} */
-export const run = async ({ install, updateJavaScript }) => {
+export const run = async ({ install, updateJavaScript, folderInfo }) => {
 	await updateViteConfig({
 		mutateViteConfig(viteConfig, containingFile, cjs) {
 			let viteImagetoolsImportedAs = findImport({ cjs, package: "vite-imagetools", typeScriptEstree: containingFile }).named["imagetools"];
@@ -47,6 +47,7 @@ export const run = async ({ install, updateJavaScript }) => {
 			}
 		},
 		updateJavaScript,
+		folderInfo,
 	});
 
 	await install({ package: "vite-imagetools" });


### PR DESCRIPTION
Fixes svelte-add/svelte-add/issues/234